### PR TITLE
Redis caching support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
 History
 =======
 
-1.8.1 (unreleased)
+1.9.0 (unreleased)
 ------------------
 
-- No changes yet.
+- Support for Redis cache in addition to Memcached
+  [dataflake]
 
 
 1.8.0 (2020-06-11)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = "1.8.1.dev0"
+version = "1.9.0.dev0"
 shortdesc = "LDAP/AD Plugin for Plone/Zope PluggableAuthService (users+groups)"
 longdesc = open(os.path.join(os.path.dirname(__file__), "README.rst")).read()
 longdesc += open(os.path.join(os.path.dirname(__file__), "TODO.rst")).read()
@@ -49,6 +49,7 @@ setup(
         "AccessControl>=3.0",
         "Acquisition",
         "bda.cache",
+        "dogpile.cache",
         "five.globalrequest",
         "node",
         "node.ext.ldap>=1.0b12",
@@ -60,6 +61,7 @@ setup(
         "Products.PluggableAuthService",
         "Products.statusmessages",
         "python-ldap>=3.2.0",
+        "redis",
         "setuptools",
         "six",
         "yafowil>=2.3.1",

--- a/src/pas/plugins/ldap/cache.py
+++ b/src/pas/plugins/ldap/cache.py
@@ -2,6 +2,7 @@
 
 from bda.cache import Memcached
 from bda.cache import NullCache
+from dogpile.cache import make_region
 from node.ext.ldap.interfaces import ICacheProviderFactory
 from pas.plugins.ldap.interfaces import ICacheSettingsRecordProvider
 from pas.plugins.ldap.interfaces import ILDAPPlugin
@@ -16,7 +17,45 @@ import threading
 import time
 
 
-class PasLdapMemcached(Memcached):
+KEY_PREFIX = 'pas.plugins.ldap.rediscache:'
+redis_cache = make_region(
+    name='pas.plugins.ldap.rediscache',
+    key_mangler=lambda key: KEY_PREFIX + key,
+    )
+
+
+class PasLdapCache(object):
+
+    def __init__(self, servers):
+        self._servers = servers
+
+    @property
+    def servers(self):
+        return self._servers
+
+    def disconnect(self):
+        pass
+
+    def __repr__(self):
+        return "<{0} {1}>".format(self.__class__.__name__, self.servers)
+
+
+class PasLdapRedisCache(PasLdapCache):
+
+    def __init__(self, servers):
+        super(PasLdapRedisCache, self).__init__(servers)
+        self._client = redis_cache.configure(
+            'dogpile.cache.redis',
+            expiration_time=300,
+            replace_existing_backend=True,
+            arguments={
+                'url': servers[0],
+                'distributed_lock': True,
+            },
+        )
+
+
+class PasLdapMemcached(Memcached, PasLdapCache):
 
     _servers = None
 
@@ -24,26 +63,19 @@ class PasLdapMemcached(Memcached):
         self._servers = servers
         super(PasLdapMemcached, self).__init__(servers)
 
-    @property
-    def servers(self):
-        return self._servers
-
-    def disconnect_all(self):
+    def disconnect(self):
         self._client.disconnect_all()
-
-    def __repr__(self):
-        return "<{0} {1}>".format(self.__class__.__name__, self.servers)
 
 
 @implementer(ICacheProviderFactory)
 class cacheProviderFactory(object):
-    # memcache factory for node.ext.ldap
+    # cache provider factory for node.ext.ldap
 
     _thread_local = threading.local()
 
     @property
     def _key(self):
-        return "_v_{0}_PasLdapMemcached".format(self.__class__.__name__)
+        return "_v_{0}_PasLdapCache".format(self.__class__.__name__)
 
     @property
     def servers(self):
@@ -63,23 +95,28 @@ class cacheProviderFactory(object):
         key = self._key
 
         # thread safety for memcached connections
-        mcd = getattr(self._thread_local, key, None)
+        cache_provider = getattr(self._thread_local, key, None)
 
-        # if mcd is set and server config has not changed
-        # return mcd
-        if mcd and frozenset(mcd.servers) == frozenset(servers):
-            return mcd
-        elif mcd:
+        # if cache_provider is set and server config has not changed
+        # return cache_provider
+        if cache_provider and \
+           frozenset(cache_provider.servers) == frozenset(servers):
+            return cache_provider
+        elif cache_provider:
             # server config has changed, close all connections
-            mcd.disconnect_all()
-            del mcd
+            cache_provider.disconnect()
+            del cache_provider
 
-        # establish new memcached connection and store
+        # establish new cache connection and store
         # it on local thread
-        mcd = PasLdapMemcached(servers)
-        setattr(self._thread_local, key, mcd)
+        svr = servers[0].lower()
+        if svr.startswith('redis') or svr.startswith('unix'):
+            cache_provider = PasLdapRedisCache(servers)
+        else:
+            cache_provider = PasLdapMemcached(servers)
+        setattr(self._thread_local, key, cache_provider)
 
-        return mcd
+        return cache_provider
 
     def __call__(self):
         return self.cache

--- a/src/pas/plugins/ldap/cache.rst
+++ b/src/pas/plugins/ldap/cache.rst
@@ -85,6 +85,8 @@ The volatile Plugin Cache:
 
 Test node.ext.ldap.cache memcached
 
+.. code-block:: pycon
+
    >>> from zope.component import queryUtility
    >>> from node.ext.ldap.interfaces import ICacheProviderFactory   
    >>> cacheFactory = queryUtility(ICacheProviderFactory)
@@ -104,7 +106,7 @@ Turn on memcached
 
    >>> from pas.plugins.ldap.cache import PasLdapMemcached
    >>> ldapprops = ldap._ldap_props
-   >>> ldapprops.memcached = u'127.0.0.1:11211'
+   >>> ldapprops.cache_server = u'127.0.0.1:11211'
    
    >>> cache = cacheFactory()
    >>> cache
@@ -121,7 +123,7 @@ Change memcached config
 
 .. code-block:: pycon
 
-   >>> ldapprops.memcached = u'127.0.0.2:11211'
+   >>> ldapprops.cache_server = u'127.0.0.2:11211'
    >>> cache is cacheFactory()
    False
    
@@ -132,24 +134,24 @@ Switch to Redis
 
 .. code-block:: pycon
 
-   >>> ldapprops.memcached = u'redis://127.0.0.1'
+   >>> ldapprops.cache_server = u'redis://127.0.0.1'
    
    >>> cache = cacheFactory()
    >>> cache
    <PasLdapRedisCache ['redis://127.0.0.1']>
 
-Check thread safety of memcached connection
+Check thread safety of cache connection
 
 .. code-block:: pycon
 
    >>> cache is cacheFactory()
    True
 
-Change memcached config
+Change cache config
 
 .. code-block:: pycon
 
-   >>> ldapprops.memcached = u'redis://127.0.0.1:6379'
+   >>> ldapprops.cache_server = u'redis://127.0.0.1:6379'
    >>> cache is cacheFactory()
    False
    

--- a/src/pas/plugins/ldap/cache.rst
+++ b/src/pas/plugins/ldap/cache.rst
@@ -127,3 +127,31 @@ Change memcached config
    
    >>> cacheFactory()
    <PasLdapMemcached ['127.0.0.2:11211']>
+
+Switch to Redis
+
+.. code-block:: pycon
+
+   >>> ldapprops.memcached = u'redis://127.0.0.1'
+   
+   >>> cache = cacheFactory()
+   >>> cache
+   <PasLdapRedisCache ['redis://127.0.0.1']>
+
+Check thread safety of memcached connection
+
+.. code-block:: pycon
+
+   >>> cache is cacheFactory()
+   True
+
+Change memcached config
+
+.. code-block:: pycon
+
+   >>> ldapprops.memcached = u'redis://127.0.0.1:6379'
+   >>> cache is cacheFactory()
+   False
+   
+   >>> cacheFactory()
+   <PasLdapRedisCache ['redis://127.0.0.1:6379']>

--- a/src/pas/plugins/ldap/plonecontrolpanel/cache.py
+++ b/src/pas/plugins/ldap/plonecontrolpanel/cache.py
@@ -8,7 +8,7 @@ from zope.component import queryUtility
 from zope.interface import implementer
 
 
-REGKEY = "pas.plugins.ldap.memcached"
+REGKEY = "pas.plugins.ldap.cache"
 
 
 class NullRecord(object):

--- a/src/pas/plugins/ldap/properties.py
+++ b/src/pas/plugins/ldap/properties.py
@@ -125,7 +125,7 @@ class BasePropertiesForm(BrowserView):
         # props.retry_delay = fetch('server.retry_delay')
         props.page_size = fetch("server.page_size")
         props.cache = fetch("cache.cache")
-        props.memcached = fetch("cache.memcached")
+        props.cache_server = fetch("cache.cache_server")
         props.timeout = fetch("cache.timeout")
         users.baseDN = fetch("users.dn")
         # build attrmap from static keys and dynamic keys inputs
@@ -261,15 +261,15 @@ class LDAPProps(object):
     timeout = propproxy("cache.timeout")
 
     @property
-    def memcached(self):
+    def cache_server(self):
         recordProvider = queryUtility(ICacheSettingsRecordProvider)
         if recordProvider is not None:
             record = recordProvider()
             return record.value
         return u"feature not available"
 
-    @memcached.setter
-    def memcached(self, value):
+    @cache_server.setter
+    def cache_server(self, value):
         recordProvider = queryUtility(ICacheSettingsRecordProvider)
         if recordProvider is not None:
             record = recordProvider()

--- a/src/pas/plugins/ldap/properties.yaml
+++ b/src/pas/plugins/ldap/properties.yaml
@@ -204,12 +204,15 @@ widgets:
         value: expr:context.props.cache
         props:
             label: Cache LDAP queries
-    - memcached:
+    - cache_server:
         factory: '#field:text'
-        value: expr:context.props.memcached
+        value: expr:context.props.cache_server
         props:
-            label: Memcached Server to use
-            help: global - same server for all ldap plugins
+            label: Cache Server to use
+            help: |
+                global - same server for all ldap plugins. Use host:server
+                for memcached and Redis URLs starting with redis: or unix: for
+                Redis.
             field.class: memcached field
             datatype: unicode
     - timeout:


### PR DESCRIPTION
This PR adds support for caching with Redis in addition to memcached.

To keep the changes minimal I only renamed one configuration variable to make it more generic and the decision about the cache implementation is based on the data you input for the cache server. If you input  `host:port` pairs you will get a Memcache-based cache, same as before. If you input Redis URLs (full URLs that start with `redis://` or `unix://`) you will get a Redis cache.